### PR TITLE
Attempt to go even faster

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,22 +13,22 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, io};
 
 // Configuration for Llama 70B. Others in config.txt
-// const DIM: usize = 8192;
-// const HIDDEN_DIM: usize = 28672;
-// const ATTN_GROUPS: usize = 8;
-// const N_LAYERS: usize = 80;
-// const N_HEADS: usize = 64;
-// const SEQ_LEN: usize = 2048;
-// const VOCAB_SIZE: usize = 32000;
-
-// Llama 13B
-const DIM: usize = 5120;
-const HIDDEN_DIM: usize = 13824;
-const ATTN_GROUPS: usize = 1;
-const N_LAYERS: usize = 40;
-const N_HEADS: usize = 40;
+const DIM: usize = 8192;
+const HIDDEN_DIM: usize = 28672;
+const ATTN_GROUPS: usize = 8;
+const N_LAYERS: usize = 80;
+const N_HEADS: usize = 64;
 const SEQ_LEN: usize = 2048;
 const VOCAB_SIZE: usize = 32000;
+
+// Llama 13B
+// const DIM: usize = 5120;
+// const HIDDEN_DIM: usize = 13824;
+// const ATTN_GROUPS: usize = 1;
+// const N_LAYERS: usize = 40;
+// const N_HEADS: usize = 40;
+// const SEQ_LEN: usize = 2048;
+// const VOCAB_SIZE: usize = 32000;
 
 // Llama 7B
 // const DIM: usize = 4096;


### PR DESCRIPTION
Two main things I did:

- As all the dimensions you're vectorizing are perfectly matching the lane sizes you can move from chunks() to chunks_exact() this avoids a branching operation allowing the compiler to evict cmp, jmp and generating epilog "in case"

- Emit a prefetching (x86_64 only - _mm_prefetech ) operation in the most inner loop doing the dequantization from zero point + scaling. It seems the compiler (or the CPU prefetech) is not catching the linear access over qzeros and generates cache misses. With the prefetch instruction we ask to load the next chunk into L1/L2[/L3] registers