### PR TITLE
Build script

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,0 @@
-[build]
-rustflags = ["-C", "target-feature=+avx,+avx2,+fma,+sse3",
-             "-C", "target-cpu=native",
-             "-C", "link-args=-Wl,-zstack-size=419430400",
-     	     "--cfg", 'model_size="13B"', 
-             "--cfg", 'quant="Q_4"', 
-             "--cfg", 'group_size="128"']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,6 @@ group_32 = []
 group_64 = []
 group_128 = []
 
-# optionally enable AVX512 if your chipset supports it
-avx512 = []
-
 # currently enables Q_4 quantization
 quantized = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,15 @@ name = "llama2_rs"
 path = "src/main.rs"
 
 [features]
-model_size = []
+# Choose between Llama2 models - these are mutually exclusive
+7B = []
+13B = []
+70B = []
+
+# optionally enable AVX512 if your chipset supports it
+avx512 = []
+
+# currently enables Q_4_128 quantization
+quantized = []
+
+default = ["13B", "quantized"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,15 @@ path = "src/main.rs"
 13B = []
 70B = []
 
+# Choose group size - these are mutually exclusive
+group_32 = []
+group_64 = []
+group_128 = []
+
 # optionally enable AVX512 if your chipset supports it
 avx512 = []
 
-# currently enables Q_4_128 quantization
+# currently enables Q_4 quantization
 quantized = []
 
-default = ["13B", "quantized"]
+default = ["13B", "group_128", "quantized"]

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ To build, you'll need the nightly toolchain, which is used by default:
 > ulimit -s 10000000 # Increase your stack memory limit. 
 ```
 
-If you get a build error you may need to change `.cargo/config` to match your chipset.
-
 You can load models from the Hugging Face hub. For example this creates a version of a [70B quantized](https://huggingface.co/TheBloke/llama-2-70b-Guanaco-QLoRA-GPTQ)) model with 4 bit quant and 64 sized groups:
 
 ```

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+fn main() {
+    // note: Cargo features are just binary flags, so this decides a more clear cfg key/value pair
+    if cfg!(feature="7B") {
+        println!("cargo:rustc-cfg=model_size=\"7B\"");
+    } else if cfg!(feature="13B") {
+        println!("cargo:rustc-cfg=model_size=\"13B\"");
+    } else  if cfg!(feature="70B") {
+        println!("cargo:rustc-cfg=model_size=\"70B\"");
+    } else {
+        panic!("Must set one of 7B, 13B or 70B features to pick a model size");
+    }
+
+    // set quantization level
+    if cfg!(feature="quantized") {
+        println!("cargo:rustc-cfg=quant=\"Q_4_128\"");
+    }
+    else {
+        println!("cargo:rustc-cfg=quant=\"no\"");
+    }
+
+    // set target-feature based on AVX512/AVX2 desired support
+    if cfg!(feature="avx512") {
+        if !std::is_x86_feature_detected!("avx512f") {
+            panic!("AVX512 is not supported on this machine");
+        }
+        println!("cargo:rustc-env=RUSTFLAGS=-C target-feature=+avx,+avx2,+fma,+sse3,+avx512f target-cpu=native");
+    }
+    else if std::is_x86_feature_detected!("avx2") {
+        println!("cargo:rustc-env=RUSTFLAGS=-C target-feature=+avx,+avx2,+fma,+sse3 target-cpu=native");
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,31 +1,65 @@
+use std::env;
+
 fn main() {
     // note: Cargo features are just binary flags, so this decides a more clear cfg key/value pair
-    if cfg!(feature="7B") {
-        println!("cargo:rustc-cfg=model_size=\"7B\"");
+    let model_size = if cfg!(feature="7B") {
+        "7B"
     } else if cfg!(feature="13B") {
-        println!("cargo:rustc-cfg=model_size=\"13B\"");
+        "13B"
     } else  if cfg!(feature="70B") {
-        println!("cargo:rustc-cfg=model_size=\"70B\"");
+        "70B"
     } else {
         panic!("Must set one of 7B, 13B or 70B features to pick a model size");
-    }
+    };
+    println!("cargo:rustc-cfg=model_size=\"{}\"", model_size);
+
+    // get group size
+    let group_size = if cfg!(feature="group_32") {
+        32
+    } else if cfg!(feature="group_64") {
+        64
+    } else if cfg!(feature="group_128") {
+        128
+    } else {
+        // ok if there's no quantization
+        0
+    };
 
     // set quantization level
     if cfg!(feature="quantized") {
-        println!("cargo:rustc-cfg=quant=\"Q_4_128\"");
+        if group_size == 0 {
+            panic!("Must set one of group_32, group_64 or group_128 features to use quantization");
+        }
+        println!("cargo:rustc-cfg=group_size=\"{}\"", group_size);
+        println!("cargo:rustc-cfg=quant=\"Q_4\"");
     }
     else {
         println!("cargo:rustc-cfg=quant=\"no\"");
     }
 
     // set target-feature based on AVX512/AVX2 desired support
-    if cfg!(feature="avx512") {
+    let avx512 = if cfg!(feature="avx512") {
         if !std::is_x86_feature_detected!("avx512f") {
-            panic!("AVX512 is not supported on this machine");
+            panic!("AVX512 is not supported on this machine, but the avx512 feature was requested");
         }
-        println!("cargo:rustc-env=RUSTFLAGS=-C target-feature=+avx,+avx2,+fma,+sse3,+avx512f target-cpu=native");
+        ",+avx512f "
     }
-    else if std::is_x86_feature_detected!("avx2") {
-        println!("cargo:rustc-env=RUSTFLAGS=-C target-feature=+avx,+avx2,+fma,+sse3 target-cpu=native");
+    else {
+        ""
+    };
+
+    let mut rustflags = [
+        "-C target-cpu=native",
+        "-C link-args=-Wl,-zstack-size=419430400"
+    ].map(String::from).to_vec();
+
+    match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+        "x86_64" => {
+            rustflags.push(format!("-C target-feature=+avx,+avx2,+fma,+sse3{}", avx512));
+        },
+        // on Mac M* devices, SIMD support is via NEON, not AVX (and is enabled via target-cpu=native by default)
+        // leave this here since we'll need explicit Accelerate linking for BLAS
+        "aarch64" | _ => {},
     }
+    println!("cargo:rustc-env=RUSTFLAGS={}", rustflags.join(" "));
 }

--- a/build.rs
+++ b/build.rs
@@ -37,17 +37,6 @@ fn main() {
         println!("cargo:rustc-cfg=quant=\"no\"");
     }
 
-    // set target-feature based on AVX512/AVX2 desired support
-    let avx512 = if cfg!(feature="avx512") {
-        if !std::is_x86_feature_detected!("avx512f") {
-            panic!("AVX512 is not supported on this machine, but the avx512 feature was requested");
-        }
-        ",+avx512f "
-    }
-    else {
-        ""
-    };
-
     let mut rustflags = [
         "-C target-cpu=native",
         "-C link-args=-Wl,-zstack-size=419430400"
@@ -55,7 +44,7 @@ fn main() {
 
     match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
         "x86_64" => {
-            rustflags.push(format!("-C target-feature=+avx,+avx2,+fma,+sse3{}", avx512));
+            rustflags.push("-C target-feature=+avx,+avx2,+fma,+sse3".to_string());
         },
         // on Mac M* devices, SIMD support is via NEON, not AVX (and is enabled via target-cpu=native by default)
         // leave this here since we'll need explicit Accelerate linking for BLAS


### PR DESCRIPTION
This one is maybe just an idea - Cargo doesn't seem to support key/value *features*, but that's the best way to let crates that depend on this choose the model size. So here I set Cargo features (e.g. "7B") and then the `build.rs` converts that to a k/v pair (`model_size = "7B"`). I'm not sure the conversion is necessary but I didn't want to mess too much with your existing setup.

Separately this sets AVX512 as a enable-able feature that errors if the host machine doesn't support AVX512. My home computer doesn't have it, so I haven't checked it.