### PR TITLE
Python interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Cargo.lock
 
 # Python extensions shouldn't be checked in
 **/*.so
+**/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,10 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+*.bin
 
-# Added by cargo
+.rtx.toml
+.venv/
 
-/target
+# Python extensions shouldn't be checked in
+**/*.so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,19 @@ edition = "2021"
 clap = { version = "4.3.23", features = ["derive"] }
 memmap2 = "0.7"
 rayon = "1.5"
+pyo3 = "0.19.0"
 
 [profile.release]
 debug = true
+
+[lib]
+name = "llama2_rs"
+crate-type = ["rlib", "cdylib"]
+path = "src/lib.rs"
+
+[[bin]]
+name = "llama2_rs"
+path = "src/main.rs"
 
 [features]
 model_size = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "click",
     "torch",
     "transformers",
-    "auto_gptq",
+    "auto_gptq <= 0.3.1",
 ]
 
 # see https://github.com/PyO3/maturin/tree/main/test-crates/pyo3-mixed-py-subdir
@@ -25,4 +25,4 @@ python-source = "python"
 module-name = "llama2_rs.llama2_rs_pylib"
 
 [project.scripts]
-export = "llama2_rs.export:main"
+convert_quantized = "llama2_rs.export:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,3 @@ dependencies = [
 features = ["pyo3/extension-module"]
 python-source = "python"
 module-name = "llama2_rs.llama2_rs_pylib"
-
-[project.scripts]
-convert_quantized = "llama2_rs.export:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["maturin>=1.2,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "llama2_rs"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+    "click",
+    "torch",
+    "transformers",
+    "auto_gptq",
+]
+
+# see https://github.com/PyO3/maturin/tree/main/test-crates/pyo3-mixed-py-subdir
+# for the directory structure
+[tool.maturin]
+features = ["pyo3/extension-module"]
+python-source = "python"
+module-name = "llama2_rs.llama2_rs_pylib"
+
+[project.scripts]
+export = "llama2_rs.export:main"

--- a/python/llama2_rs/__init__.py
+++ b/python/llama2_rs/__init__.py
@@ -1,0 +1,2 @@
+# this is the Rust PyO3 code in a .so file in this directory if compiled.
+from .llama2_rs_pylib import *

--- a/python/llama2_rs/__init__.py
+++ b/python/llama2_rs/__init__.py
@@ -1,2 +1,5 @@
 # this is the Rust PyO3 code in a .so file in this directory if compiled.
 from .llama2_rs_pylib import *
+
+START = 1
+RET = 13

--- a/python/llama2_rs/__init__.pyi
+++ b/python/llama2_rs/__init__.pyi
@@ -1,0 +1,1 @@
+from llama2_rs_pylib import *

--- a/python/llama2_rs/export.py
+++ b/python/llama2_rs/export.py
@@ -1,10 +1,14 @@
 """
 This script exports the AutoGPT-Q Llama 2 weights in llama2rs.bin format.
 """
+import pathlib
 import click
 import struct
 import torch
+from torch import nn
 from auto_gptq import AutoGPTQForCausalLM
+from auto_gptq.nn_modules import qlinear
+from transformers.models.llama import modeling_llama
 
 def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> tuple[torch.tensor, torch.tensor]:
     freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
@@ -14,67 +18,58 @@ def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> tuple[to
     freqs_sin = torch.sin(freqs)  # imaginary part
     return freqs_cos, freqs_sin
 
-def export(model2, filepath='model.bin'):
+def export(model_wrapper: nn.Module, path: pathlib.Path):
     """export the model weights in fp32 into .bin file to be read from C"""
-    f = open(filepath, 'wb')
-    p = {}
+    f = open(path, 'wb')
 
-    model = model2.model.model
+    print(model_wrapper.model)
+    model = model_wrapper.model.model
 
-    p['dim'] = model.layers[0].mlp.up_proj.g_idx.shape[0]
-    p['n_layers'] = len(model.layers)
-    print(model2.model)
-    def serialize(k):
-        w = None
-        if isinstance(k, torch.Tensor):
-            w = k
-        elif "GeneralQuantLinear" not in str(k.__class__):
-            w = k.weight
-        offset = torch.tensor([0, 4, 8, 12, 16, 20, 24, 28])
-        if w is None:
-            def rearrange(k):
-                order = k.g_idx.cpu().argsort(stable=True)
-                extract = (k.qweight.cpu()[:, None, :] >> offset[:, None]) & (2**4-1)
-                extract = extract.view(k.g_idx.shape[0], -1)[order]
-                store = extract << offset.repeat(1, extract.shape[0] // 8)[..., None]
-                store = store.view(k.qweight.shape[0], 8, k.qweight.shape[1])
-                final = torch.zeros(*k.qweight.shape, dtype=int)
-                for i in range(8):
-                    final = final | store[:, i]
-                # print(final.shape, k.qweight.shape)
-                # print(order)
-                # print(final)
-                # print(k.qweight)
+    Serializable = torch.Tensor | qlinear.GeneralQuantLinear | modeling_llama.LlamaRMSNorm | nn.modules.linear.Linear
+    def serialize(k: Serializable):
+        match k:
+            case torch.Tensor() | modeling_llama.LlamaRMSNorm() | nn.modules.linear.Linear():
+                if isinstance(k, torch.Tensor):
+                    w = k
+                else:
+                    w = k.weight
 
-                return final
-            for w in [rearrange(k).type(torch.int32), k.qzeros.type(torch.int32), k.scales.type(torch.float32), k.g_idx.argsort(stable=True).type(torch.int32)]:
+                print("regular")
                 print(w.shape)
-                t = w.T.contiguous().view(-1).detach().cpu().numpy()
+                t = w.contiguous().view(-1).detach().cpu().type(torch.float32).numpy()
                 f.write(memoryview(t))
-        else:
-            if hasattr(k, "weight"):
-                w = k.weight
-            else:
-                w = k
-            print("Regular")
-            print(w.shape)
-            t = w.contiguous().view(-1).detach().cpu().type(torch.float32).numpy()
-            f.write(memoryview(t))
-
-        # del state_dict[key]
-
+            case qlinear.GeneralQuantLinear():
+                # more complex case
+                print("quantized")
+                offset = torch.tensor([0, 4, 8, 12, 16, 20, 24, 28])
+                def rearrange(k):
+                    order = k.g_idx.cpu().argsort(stable=True)
+                    extract = (k.qweight.cpu()[:, None, :] >> offset[:, None]) & (2**4-1)
+                    extract = extract.view(k.g_idx.shape[0], -1)[order]
+                    store = extract << offset.repeat(1, extract.shape[0] // 8)[..., None]
+                    store = store.view(k.qweight.shape[0], 8, k.qweight.shape[1])
+                    final = torch.zeros(*k.qweight.shape, dtype=int)
+                    for i in range(8):
+                        final = final | store[:, i]
+                    return final
+                for w in [rearrange(k).type(torch.int32), k.qzeros.type(torch.int32), k.scales.type(torch.float32), k.g_idx.argsort(stable=True).type(torch.int32)]:
+                    print(w.shape)
+                    t = w.T.contiguous().view(-1).detach().cpu().numpy()
+                    f.write(memoryview(t))
 
     # first write out the header
+    p = {}
+    p['dim'] = model.layers[0].mlp.up_proj.g_idx.shape[0]
+    p['n_layers'] = len(model.layers)
     p['n_heads'] = model.layers[0].self_attn.num_heads
-    hidden_dim = model.layers[0].mlp.up_proj.qweight.shape[1]
-
-    p['vocab_size'] = 32000
+    p['hidden_dim'] = model.layers[0].mlp.up_proj.qweight.shape[1]
+    p['vocab_size'] = model.embed_tokens.num_embeddings
     p['max_seq_len'] = 2048
 
     n_kv_heads = p.get('n_kv_heads') or p['n_heads']
     header = struct.pack(
         'iiiiiii',
-        p['dim'], hidden_dim, p['n_layers'], p['n_heads'],
+        p['dim'], p['hidden_dim'], p['n_layers'], p['n_heads'],
         n_kv_heads, -p['vocab_size'], p['max_seq_len']
     )
     # NOTE ABOVE: -ve vocab_size is indicating that the classifier weights are present
@@ -83,7 +78,7 @@ def export(model2, filepath='model.bin'):
 
     # next write out the embedding weights
     print("writing tok_embeddings...")
-    f.write(memoryview(torch.tensor([model2.config.rms_norm_eps]).numpy()))
+    f.write(memoryview(torch.tensor([model_wrapper.config.rms_norm_eps]).numpy()))
     serialize(model.embed_tokens)
 
     # now all the layers
@@ -108,27 +103,30 @@ def export(model2, filepath='model.bin'):
     serialize(freqs_sin[:p['max_seq_len']])
 
     # finally write the output weights
-    serialize(model2.model.lm_head)
+    serialize(model_wrapper.model.lm_head)
 
     f.close()
-    print(f"wrote {filepath}")
+    print(f"wrote {path}")
 
 @click.command()
-@click.argument("output-path")
-@click.argument("model-name")
-@click.argument("revision")
-def main(output_path: str, model_name: str, revision: str):
+@click.argument("output-path", type=click.Path(exists=False, path_type=pathlib.Path))
+@click.argument("model-name", type=str)
+@click.argument("revision", type=str)
+def main(output_path: pathlib.Path, model_name: str, revision: str):
+    print(f"Loading model {model_name} / {revision} ...")
     model = AutoGPTQForCausalLM.from_quantized(
         model_name,
-        use_safetensors=True,
         revision=revision,
+        model_basename="model",
+        use_safetensors=True,
+        trust_remote_code=False,
+        device="cpu",
         inject_fused_attention = False,
         inject_fused_mlp = False,
-        trust_remote_code=True,
-        device="cpu",
         use_triton=False,
         quantize_config=None,
     )
+    print("Exporting...")
     export(model, output_path)
 
 if __name__ == '__main__':

--- a/python/llama2_rs/llama2_rs_pylib.pyi
+++ b/python/llama2_rs/llama2_rs_pylib.pyi
@@ -1,0 +1,30 @@
+from typing import Any
+
+class LlamaModel:
+    # we could define Config later
+    config: Any
+    
+    def __new__(cls, checkpoint: str, debug: bool = False) -> LlamaModel:
+        ...
+
+class Random:
+    def __new__(cls) -> Random:
+        ...
+
+class Tokenizer:
+    def __new__(cls, filename: str) -> Tokenizer:
+        ...
+
+    def bpe_encode(self, text: str) -> list[int]:
+        ...
+
+def generate(
+    model: LlamaModel,
+    tokenizer: Tokenizer,
+    prompt: str,
+    steps: int,
+    random: Random,
+    temperature: float = 0.0,
+    print_tokens: bool = False
+) -> tuple[int, list[str]]:
+    ...

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -57,6 +57,7 @@ pub mod group {
 
 pub use constants::*;
 pub use group::*;
+use pyo3::pyclass;
 
 // Head size is constant but standardized.
 pub const HEAD_SIZE: usize = DIM / N_HEADS;
@@ -66,8 +67,9 @@ pub const KV_DIM: usize = DIM / ATTN_GROUPS;
 pub const N_KV_HEADS: usize = N_HEADS / ATTN_GROUPS;
 
 // This is kept in for debugging.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
+#[pyclass]
 pub struct Config {
     dim: usize,        // transformer dimension
     hidden_dim: usize, // for ffn layers

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,0 +1,151 @@
+use pyo3::pyfunction;
+
+use crate::models::{RunState, TWeights, transformer, softmax};
+use crate::tokenizer::{Tokenizer, START, Token, RET};
+use crate::constants::VOCAB_SIZE;
+use crate::util::{Random, time_in_ms, argmax};
+use crate::LlamaModel;
+use crate::util::{get_token, print_token};
+
+/// For the prompt, fills the caches by running transformer.
+/// While not strictly necessary, this can lead to faster
+/// Performance by batching computation. Should lead to
+/// Identical results.
+pub fn prefill<const A: usize>(
+    pos: &mut usize,
+    state: &mut RunState,
+    prompt_tokens: &Vec<usize>,
+    tokenizer: &Tokenizer,
+    weights: &TWeights,
+    print_tokens: bool
+) {
+    while *pos + A < prompt_tokens.len() {
+        let mut tokens = [0; A];
+        let mut positions = [0; A];
+        let mut fake_logits = [[0.0; VOCAB_SIZE]; 1];
+        for i in 0..A {
+            let next = if *pos == 0 {
+                START
+            } else {
+                prompt_tokens[*pos - 1]
+            };
+            positions[i] = *pos;
+            tokens[i] = next;
+            *pos += 1;
+            let token = next;
+            if print_tokens {
+                print_token(get_token(tokenizer, token, next));
+            }
+        }
+        transformer(&mut fake_logits, &tokens, &positions, state, weights);
+    }
+}
+
+// NOTE: this pyo3 signature only applies to Python code (i.e. in Rust code you must specify print_tokens).
+#[pyfunction]
+#[pyo3(signature = (model, tokenizer, prompt, steps, random, temperature=0.0, print_tokens=false))]
+pub fn generate(
+    model: &LlamaModel,
+    tokenizer: &Tokenizer,
+    prompt: &str,
+    steps: usize,
+    random: &mut Random,
+    temperature: f32,
+    print_tokens: bool
+) -> (i64, Vec<String>) {
+    // create and init the application RunState
+    let mut state: Box<RunState> = RunState::new();
+
+    // process the prompt, if any
+    let prompt_tokens = if !prompt.is_empty() {
+        let prompt = format!(" {}", prompt.trim());
+        tokenizer.bpe_encode(&prompt)
+    } else {
+        Vec::new()
+    };
+
+    let mut ret = Vec::new(); // will store generated tokens
+
+    // start the main loop
+    let start: i64 = time_in_ms(); // used to time our code, only initialized after first iteration
+    let mut next; // will store the next token in the sequence
+    let mut pos = 0; // position in the sequence
+
+    // Do a little backoff to handle different sizes.This costs us compilation time,
+    // But allows us to compile versions of with the longest lnength prefill possible.
+    prefill::<64>(&mut pos, &mut state, &prompt_tokens, tokenizer, model.weights, print_tokens);
+    prefill::<32>(&mut pos, &mut state, &prompt_tokens, tokenizer, model.weights, print_tokens);
+    prefill::<16>(&mut pos, &mut state, &prompt_tokens, tokenizer, model.weights, print_tokens);
+    prefill::<8>(&mut pos, &mut state, &prompt_tokens, tokenizer, model.weights, print_tokens);
+    prefill::<4>(&mut pos, &mut state, &prompt_tokens, tokenizer, model.weights, print_tokens);
+    prefill::<2>(&mut pos, &mut state, &prompt_tokens, tokenizer, model.weights, print_tokens);
+
+    let mut token: Token = if pos == 0 {
+        START
+    } else {
+        prompt_tokens[pos - 1]
+    }; // init with token 1 (=BOS), as done in Llama-2 sentencepiece tokenizer
+    
+    if print_tokens {
+        let token_str = get_token(tokenizer, token, token);
+        print_token(token_str);
+    }
+
+    let mut outputs = Vec::new();
+    let mut raw_logits = [[0.0; VOCAB_SIZE]; 1];
+    while pos < steps {
+        // forward the transformer to get logits for the next token
+        let tokens = [token];
+        let positions = [pos];
+
+        transformer(&mut raw_logits, &tokens, &positions, &mut state, model.weights);
+        let logits = &mut raw_logits[0];
+        if pos < prompt_tokens.len() {
+            // if we are still processing the input prompt, force the next prompt token
+            next = prompt_tokens[pos];
+            // println!("{}", logits[next]);
+        } else {
+            // sample the next token
+            if temperature == 0.0 {
+                // greedy argmax sampling: take the token with the highest probability
+                next = argmax(logits);
+                // println!("{}", logits[next]);
+            } else {
+                // apply the temperature to the logits
+                for q in 0..VOCAB_SIZE {
+                    logits[q] /= temperature;
+                }
+                // apply softmax to the logits to get the probabilities for next token
+                softmax(&mut logits[..VOCAB_SIZE]);
+                // we sample from this distribution to get the next token
+                next = random.sample(logits, VOCAB_SIZE);
+            }
+        };
+        
+        // following BOS token (1), sentencepiece decoder strips any leading whitespace (see PR #89)
+        //println!("{} {}", next, state.logits[next]);
+        let token_str = get_token(tokenizer, token, next);
+        ret.push(token_str.to_string());
+        if print_tokens {
+            print_token(token_str);
+        }
+
+        // advance forward
+        token = next;
+        outputs.push(token);
+        let l = outputs.len();
+
+        // Heuristic stopping criteria.
+        if l > 6
+            && outputs[l - 1] == RET
+            && outputs[l - 2] == RET
+            && outputs[l - 3] == RET
+            && outputs[l - 4] == RET
+        {
+            break;
+        }
+        pos += 1;
+    }
+
+    ((time_in_ms() - start), ret)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,10 @@ pub mod models;
 pub mod tokenizer;
 pub mod util;
 
+
+
 #[pymodule]
 fn llama2_rs_pylib (_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<tokenizer::Tokenizer>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
 #![feature(portable_simd)]
 
+use std::{fs::File, io::{SeekFrom, Seek}, mem};
+
+use constants::Config;
+use memmap2::{Mmap, MmapOptions};
+use models::TWeights;
 use pyo3::prelude::*;
 
 pub mod constants;
@@ -8,10 +13,37 @@ pub mod models;
 pub mod tokenizer;
 pub mod util;
 
+#[allow(dead_code)]
+#[pyclass]
+pub struct LoadedModel {
+    mmap: Mmap,
+    #[pyo3(get)]
+    pub config: Config,
+    pub weights: &'static TWeights,
+}
 
+#[pymethods]
+impl LoadedModel {
+    #[new]
+    pub fn from_file(checkpoint: &str, debug: bool) -> LoadedModel {
+        let mut file = File::open(checkpoint).unwrap();
+        let config = Config::load(&mut file);
+        if debug {
+            println!("Configuration: {config:?}");
+        }
+        let start = file.seek(SeekFrom::Current(0)).unwrap();
+        let mmap = unsafe { MmapOptions::new().offset(start).map(&file).unwrap() };
+        assert_eq!(mmap.len(), mem::size_of::<TWeights>());
+        let weights = unsafe { &*(mmap.as_ptr() as *const TWeights) };
+        LoadedModel { mmap, config, weights }
+    }
+}
 
 #[pymodule]
 fn llama2_rs_pylib (_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<tokenizer::Tokenizer>()?;
+    m.add_class::<util::Random>()?;
+    m.add_class::<constants::Config>()?;
+    m.add_class::<LoadedModel>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,11 @@ pub mod gptq;
 pub mod models;
 pub mod tokenizer;
 pub mod util;
+pub mod inference;
 
 #[allow(dead_code)]
 #[pyclass]
-pub struct LoadedModel {
+pub struct LlamaModel {
     mmap: Mmap,
     #[pyo3(get)]
     pub config: Config,
@@ -23,19 +24,21 @@ pub struct LoadedModel {
 }
 
 #[pymethods]
-impl LoadedModel {
+impl LlamaModel {
+    // NOTE: this pyo3 signature only applies to Python code (i.e. in Rust code you must specify debug).
     #[new]
-    pub fn from_file(checkpoint: &str, debug: bool) -> LoadedModel {
+    #[pyo3(signature = (checkpoint, debug=false))]
+    pub fn from_file(checkpoint: &str, debug: bool) -> LlamaModel {
         let mut file = File::open(checkpoint).unwrap();
         let config = Config::load(&mut file);
         if debug {
             println!("Configuration: {config:?}");
         }
-        let start = file.seek(SeekFrom::Current(0)).unwrap();
+        let start = file.stream_position().unwrap();
         let mmap = unsafe { MmapOptions::new().offset(start).map(&file).unwrap() };
         assert_eq!(mmap.len(), mem::size_of::<TWeights>());
         let weights = unsafe { &*(mmap.as_ptr() as *const TWeights) };
-        LoadedModel { mmap, config, weights }
+        LlamaModel { mmap, config, weights }
     }
 }
 
@@ -44,6 +47,7 @@ fn llama2_rs_pylib (_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<tokenizer::Tokenizer>()?;
     m.add_class::<util::Random>()?;
     m.add_class::<constants::Config>()?;
-    m.add_class::<LoadedModel>()?;
+    m.add_class::<LlamaModel>()?;
+    m.add_wrapped(wrap_pyfunction!(inference::generate))?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+#![feature(portable_simd)]
+
+use pyo3::prelude::*;
+
+pub mod constants;
+pub mod gptq;
+pub mod models;
+pub mod tokenizer;
+pub mod util;
+
+#[pymodule]
+fn llama2_rs_pylib (_py: Python, m: &PyModule) -> PyResult<()> {
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,21 +5,15 @@
 //! Rust note: These are built into the code to allo for full optimization
 //! You can select which is used with --cfg model_size=70B.
 
-mod constants;
-mod gptq;
-mod models;
-mod tokenizer;
-mod util;
-
-use constants::*;
+use llama2_rs::constants::*;
 use memmap2::MmapOptions;
-use models::{softmax, transformer, RunState, TWeights};
+use llama2_rs::models::{softmax, transformer, RunState, TWeights};
 use std::fs::File;
 use std::io;
 use std::io::{Seek, SeekFrom, Write};
 use std::mem;
-use tokenizer::{Token, Tokenizer, RET, START};
-use util::{argmax, time_in_ms, Random};
+use llama2_rs::tokenizer::{Token, Tokenizer, RET, START};
+use llama2_rs::util::{argmax, time_in_ms, Random};
 
 fn print_token(tokenizer: &Tokenizer, token: Token, next: Token) {
     let token_str = if token == 1 && tokenizer.vocab[next].starts_with(' ') {

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,6 +3,7 @@ use crate::constants::{
     ATTN_GROUPS, BITS, DIM, GROUPSIZE, HEAD_SIZE, HIDDEN_DIM, KV_DIM, N_HEADS, N_KV_HEADS,
     N_LAYERS, SEQ_LEN, VOCAB_SIZE,
 };
+use pyo3::pyclass;
 use rayon::prelude::*;
 
 pub struct RunState {
@@ -121,6 +122,7 @@ mod model {
     type AttKV = [QLinear<DIM, KV_DIM, DIM_GROUPS, DIM_G, KV_DIM_G>; N_LAYERS];
 
     #[repr(C)]
+    #[pyclass]
     pub struct QTransformerWeights {
         pub rms_eps: f32,
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,5 +1,7 @@
 use std::fs::File;
 
+use pyo3::{pyclass, pymethods};
+
 use crate::constants::VOCAB_SIZE;
 use crate::util::{read_float, read_str, read_usize, str_lookup};
 pub type Token = usize;
@@ -8,6 +10,7 @@ pub const START: Token = 1;
 pub const RET: Token = 13;
 
 #[derive(Debug)]
+#[pyclass]
 pub struct Tokenizer {
     pub vocab: Vec<String>,
     vocab_scores: Vec<f32>,
@@ -31,8 +34,17 @@ impl Tokenizer {
         }
         tokenizer
     }
+}
 
-    pub fn bpe_encode(self: &Self, text: &str) -> Vec<Token> {
+#[pymethods]
+impl Tokenizer {
+    #[new]
+    pub fn new(filename: &str) -> Tokenizer {
+        let mut file = File::open(filename).expect(format!("Failed to open {}", filename).as_str());
+        Tokenizer::load(&mut file)
+    }
+
+    pub fn bpe_encode(&self, text: &str) -> Vec<Token> {
         let mut tokens: Vec<Token> = Vec::new();
         let mut digits: Vec<bool> = Vec::new();
         let mut spaces: Vec<bool> = Vec::new();

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,8 @@ use std::fs::File;
 use std::io::Read;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use pyo3::{pyclass, pymethods};
+
 pub fn read_float(file: &mut File) -> f32 {
     let mut buf = [0u8; 4];
     file.read_exact(&mut buf).unwrap();
@@ -47,10 +49,14 @@ pub fn time_in_ms() -> i64 {
 }
 
 // Probably should just use Rust random. This came from llama2.c
+#[pyclass]
 pub struct Random {
     seed: u64,
 }
+
+#[pymethods]
 impl Random {
+    #[staticmethod]
     pub fn new() -> Random {
         // seed rng with time. if you want deterministic behavior use temperature 0.0
         Random {
@@ -61,7 +67,7 @@ impl Random {
         }
     }
 
-    fn random_u32(self: &mut Self) -> u32 {
+    fn random_u32(&mut self) -> u32 {
         // xorshift rng: https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
         self.seed ^= self.seed >> 12;
         self.seed ^= self.seed << 25;
@@ -69,12 +75,15 @@ impl Random {
         (self.seed.wrapping_mul(0x2545_f491_4f6c_dd1d) >> 32) as u32
     }
 
-    fn random(self: &mut Self) -> f32 {
+    fn random(&mut self) -> f32 {
         // random float32 in [0,1)
         (self.random_u32() >> 8) as f32 / 16777216.0
     }
+}
 
-    pub fn sample(self: &mut Self, probabilities: &[f32], n: usize) -> usize {
+// this isn't exposed to Python since we don't have a conversion to &[f32]
+impl Random {
+    pub fn sample(&mut self, probabilities: &[f32], n: usize) -> usize {
         // sample index from probabilities, they must sum to 1
         let r = self.random();
         let mut cdf = 0.0;

--- a/tests/test_model_can_run.py
+++ b/tests/test_model_can_run.py
@@ -1,0 +1,24 @@
+"""
+NOTE! This test is meant to be run locally, since there's no obvious way to distribute the large binaries that
+are required at the moment. In the future this will change.
+
+Mostly this code is here as an example for users of the Python interface.
+"""
+import llama2_rs
+
+def test_llama2_13b_4_128act_can_generate():
+    model = llama2_rs.LlamaModel("llama2_13b_4_128act.bin", False)
+    tokenizer = llama2_rs.Tokenizer("tokenizer.bin")
+    random = llama2_rs.Random()
+    response = llama2_rs.generate(
+        model,
+        tokenizer,
+        "Tell me zero-cost abstractions in Rust ",
+        50,
+        random, 
+        0.0
+    )
+    
+    # mostly we're asserting that we didn't crash so far.
+    assert isinstance(response[0], int)
+    assert isinstance(response[1], list)

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,24 @@
+import torch
+from transformers import AutoTokenizer, pipeline, logging
+from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
+
+import llama2_rs
+
+model_name_or_path = "TheBloke/llama-2-13B-Guanaco-QLoRA-GPTQ"
+model_basename = "model" 
+
+def test_tokenizer_1():
+    tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True)
+    tokenizer_rs = llama2_rs.Tokenizer("tokenizer.bin")
+
+    # NOTE! this doesn't work if there's a space at the beginning or end of the prompt
+    TEST_PROMPTS = [
+        "The climate change need to be properly addressed through the",
+        "Please give me 200 words about deep learning.",
+        # " Can you teach me about lifetimes in Rust using examples?",
+        # "I want to learn about the Rust borrow checker. ",
+    ]
+    for prompt in TEST_PROMPTS:
+        tokens_python = tokenizer(prompt, return_tensors='pt').input_ids.view(-1)
+        tokens_rs = torch.tensor(tokenizer_rs.bpe_encode(" " + prompt.strip()))
+        assert (tokens_python[1:] == tokens_rs).all(), prompt

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,6 +1,5 @@
 import torch
-from transformers import AutoTokenizer, pipeline, logging
-from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
+from transformers import AutoTokenizer
 
 import llama2_rs
 


### PR DESCRIPTION
Does the following:
1. Creates a Python package `llama2_rs` in addition to the existing binary (also called `llama2_rs`) using PyO3, which exposes an interface for doing inference from Python. You can see an example in `tests/test_model_can_run.py`
2. Moves some of the code needed by both paths (e.g. `prefill` and `generate`) into a new `inference.rs` so it can be used from both places.
3. Wraps up the `&TWeights` into a new struct `LlamaModel` that holds the `mmap` as well.

Notes:
- Includes the change in the `export.py` PR since it was useful for testing.
- I think some of the names could be changed, in particular maybe just `llama2` instead of `llama2_rs`?
- Note the pinned auto-gptq version... I thought it safest until we figure out what's going on with https://github.com/srush/llama2.rs/issues/23
- `cargo build --release` does still generate a binary here, but if you want the Python package installed you want to run: `pip install maturin; maturin develop --release`, so if you decide to merge, might need a docs change.

Next up write a check that the `matvec` results are the same in AutoGPTQ and here?