### PR TITLE
Made Python support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 clap = { version = "4.3.23", features = ["derive"] }
 memmap2 = "0.7"
 rayon = "1.5"
-pyo3 = "0.19.0"
+pyo3 = { version = "0.19.0", optional = true}
 
 [profile.release]
 debug = true
@@ -25,3 +25,4 @@ path = "src/main.rs"
 
 [features]
 model_size = []
+python = ["pyo3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,6 @@ dependencies = [
 # see https://github.com/PyO3/maturin/tree/main/test-crates/pyo3-mixed-py-subdir
 # for the directory structure
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "python"]
 python-source = "python"
 module-name = "llama2_rs.llama2_rs_pylib"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -57,6 +57,8 @@ pub mod group {
 
 pub use constants::*;
 pub use group::*;
+
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 
 // Head size is constant but standardized.
@@ -69,7 +71,7 @@ pub const N_KV_HEADS: usize = N_HEADS / ATTN_GROUPS;
 // This is kept in for debugging.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct Config {
     dim: usize,        // transformer dimension
     hidden_dim: usize, // for ffn layers

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "python")]
 use pyo3::pyfunction;
 
 use crate::models::{RunState, TWeights, transformer, softmax};
@@ -42,8 +43,8 @@ pub fn prefill<const A: usize>(
 }
 
 // NOTE: this pyo3 signature only applies to Python code (i.e. in Rust code you must specify print_tokens).
-#[pyfunction]
-#[pyo3(signature = (model, tokenizer, prompt, steps, random, temperature=0.0, print_tokens=false))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (model, tokenizer, prompt, steps, random, temperature=0.0, print_tokens=false)))]
 pub fn generate(
     model: &LlamaModel,
     tokenizer: &Tokenizer,

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,6 +3,7 @@ use crate::constants::{
     ATTN_GROUPS, BITS, DIM, GROUPSIZE, HEAD_SIZE, HIDDEN_DIM, KV_DIM, N_HEADS, N_KV_HEADS,
     N_LAYERS, SEQ_LEN, VOCAB_SIZE,
 };
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 use rayon::prelude::*;
 
@@ -122,7 +123,7 @@ mod model {
     type AttKV = [QLinear<DIM, KV_DIM, DIM_GROUPS, DIM_G, KV_DIM_G>; N_LAYERS];
 
     #[repr(C)]
-    #[pyclass]
+    #[cfg_attr(feature = "python", pyclass)]
     pub struct QTransformerWeights {
         pub rms_eps: f32,
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 
+#[cfg(feature = "python")]
 use pyo3::{pyclass, pymethods};
 
 use crate::constants::VOCAB_SIZE;
@@ -10,7 +11,7 @@ pub const START: Token = 1;
 pub const RET: Token = 13;
 
 #[derive(Debug)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct Tokenizer {
     pub vocab: Vec<String>,
     vocab_scores: Vec<f32>,
@@ -36,9 +37,7 @@ impl Tokenizer {
     }
 }
 
-#[pymethods]
 impl Tokenizer {
-    #[new]
     pub fn new(filename: &str) -> Tokenizer {
         let mut file = File::open(filename).expect(format!("Failed to open {}", filename).as_str());
         Tokenizer::load(&mut file)
@@ -106,5 +105,19 @@ impl Tokenizer {
                 }
             }
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Tokenizer {
+    #[new]
+    pub fn new_py(filename: &str) -> Tokenizer {
+        Tokenizer::new(filename)
+    }
+
+    #[pyo3(name = "bpe_encode")]
+    pub fn bpe_encode_py(&self, text: &str) -> Vec<Token> {
+        self.bpe_encode(text)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{Read, self, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(feature = "python")]
 use pyo3::{pyclass, pymethods};
 
 use crate::tokenizer::{Tokenizer, Token};
@@ -51,14 +52,12 @@ pub fn time_in_ms() -> i64 {
 }
 
 // Probably should just use Rust random. This came from llama2.c
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct Random {
     seed: u64,
 }
 
-#[pymethods]
 impl Random {
-    #[new]
     pub fn new() -> Random {
         // seed rng with time. if you want deterministic behavior use temperature 0.0
         Random {
@@ -80,6 +79,15 @@ impl Random {
     fn random(&mut self) -> f32 {
         // random float32 in [0,1)
         (self.random_u32() >> 8) as f32 / 16777216.0
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Random {
+    #[new]
+    pub fn new_py() -> Random {
+        Random::new()
     }
 }
 


### PR DESCRIPTION
This wraps a bunch of the Python scaffolding behind a feature `python` so you can compile the binary without pyo3 at all. The default `pip install .` and `maturin build` commands use the `python` feature so there's no change necessary to README, I think.

Shrinks the binary from `38MB` to `31MB` on my machine.